### PR TITLE
Issue #4: Fix collapse error (Uncaught TypeError: $.camelCase is not a function).

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -89,7 +89,7 @@
 
     if (!$.support.transition) return complete.call(this)
 
-    var scrollSize = $.camelCase(['scroll', dimension].join('-'))
+    var scrollSize = 'scroll' + (dimension === 'width' ? 'Width' : 'Height')
 
     this.$element
       .one('bsTransitionEnd', $.proxy(complete, this))


### PR DESCRIPTION
jQuery camelCase was deprecated and now removed in 4.0.0.

Fixes https://github.com/entreprise7pro/bootstrap/issues/4