### PR TITLE
Add package type "drupal-library" for composer/installers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
   "name": "entreprise7pro/bootstrap",
   "description": "The most popular front-end framework for developing responsive, mobile first projects on the web with jQuery v4 support.",
+  "type": "drupal-library",
   "keywords": [
     "css",
     "js",


### PR DESCRIPTION
Using composer/installers, the package can be placed in the libraries directory just by package type without additional configuration.